### PR TITLE
Fix issue #20: range error when dragging the indicator too far in right direction

### DIFF
--- a/lib/src/widgets/custom_animated_toggle_switch.dart
+++ b/lib/src/widgets/custom_animated_toggle_switch.dart
@@ -434,7 +434,7 @@ class _CustomAnimatedToggleSwitchState<T>
 
   void _onDragEnd() {
     if (_animationInfo.toggleMode != ToggleMode.dragged) return;
-    int index = _animationInfo.end.round();
+    int index = _animationInfo.end.round().clamp(0, widget.values.length-1);
     T newValue = widget.values[index];
     if (widget.current != newValue) widget.onChanged?.call(newValue);
     _animationInfo = _animationInfo.none(current: _animationInfo.end);


### PR DESCRIPTION
This is my proposed fix for issue #20 